### PR TITLE
Allow fuzziness to be any string

### DIFF
--- a/packages/vue/src/utils/vueTypes.js
+++ b/packages/vue/src/utils/vueTypes.js
@@ -57,7 +57,7 @@ const types = {
 	filterLabel: VueTypes.string,
 	func: VueTypes.func,
 	funcRequired: VueTypes.func.isRequired,
-	fuzziness: VueTypes.oneOf([0, 1, 2, 'AUTO']),
+	fuzziness: VueTypes.string,
 	headers: VueTypes.object,
 	hits: VueTypes.arrayOf(VueTypes.object),
 	iconPosition: VueTypes.oneOf(['left', 'right']),


### PR DESCRIPTION
You can have fuzziness strings like `AUTO:5,10`, see [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/common-options.html#fuzziness). With the current setup, it's not possible to set this prop correctly on a component.

I do not believe there is an easy way to make sure it only allows valid values here, so just letting it be a string is fine.